### PR TITLE
[SDKS-486]: Update featuresRefreshRate to be 5 seconds

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+3.0.1 (March 7, 2019)
+ - Updated Splits refreshing rate.
 3.0.0 (Feb 19, 2019)
  - Updated SDK Parity.
  - BREAKING CHANGE: Moved Impressions to Single Queue.

--- a/splitio/conf/defaults.go
+++ b/splitio/conf/defaults.go
@@ -1,12 +1,13 @@
 package conf
 
 const (
-	defaultHTTPTimeout      = 30
-	defaultTaskPeriod       = 30
-	defaultRedisHost        = "localhost"
-	defaultRedisPort        = 6379
-	defaultRedisDb          = 0
-	defaultSegmentQueueSize = 500
-	defaultSegmentWorkers   = 10
-	defaultBlockUntilReady  = 60
+	defaultHTTPTimeout        = 30
+	defaultTaskPeriod         = 30
+	defaultRedisHost          = "localhost"
+	defaultRedisPort          = 6379
+	defaultRedisDb            = 0
+	defaultSegmentQueueSize   = 500
+	defaultSegmentWorkers     = 10
+	defaultBlockUntilReady    = 60
+	defaultFeatureRefreshRate = 5
 )

--- a/splitio/conf/sdkconf.go
+++ b/splitio/conf/sdkconf.go
@@ -118,7 +118,7 @@ func Default() *SplitSdkConfig {
 			LatencySync:    defaultTaskPeriod,
 			ImpressionSync: defaultTaskPeriod,
 			SegmentSync:    defaultTaskPeriod,
-			SplitSync:      defaultTaskPeriod,
+			SplitSync:      defaultFeatureRefreshRate,
 			EventsSync:     defaultTaskPeriod,
 		},
 		Advanced: AdvancedConfig{

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -1,4 +1,4 @@
 package splitio
 
 // Version contains a string with the split sdk version
-const Version = "3.0.0"
+const Version = "3.0.1-rc1"


### PR DESCRIPTION
# GO SDK

## Tickets covered:
* [SDKS-486](https://splitio.atlassian.net/browse/SDKS-486)

## What did you accomplish?
* Updated refreshing rate for Split to 5 seconds.

## How to test new changes?
* `go test ./...`