### PR TITLE
[SDKS-575]: Store dynamic configs on splitChanges

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+3.1.0 (April , 2019)
+ - Added getTreatmentWithConfig and getTreatmentsWithConfig methods.
 3.0.1 (March 8, 2019)
  - Updated Splits refreshing rate.
 3.0.0 (Feb 19, 2019)

--- a/splitio/engine/grammar/split.go
+++ b/splitio/engine/grammar/split.go
@@ -87,3 +87,8 @@ func (s *Split) Conditions() []*Condition {
 func (s *Split) ChangeNumber() int64 {
 	return s.splitData.ChangeNumber
 }
+
+// Configurations returns the configurations for this split
+func (s *Split) Configurations() map[string]string {
+	return s.splitData.Configurations
+}

--- a/splitio/service/api/http_fetchers_test.go
+++ b/splitio/service/api/http_fetchers_test.go
@@ -45,6 +45,18 @@ func TestSpitChangesFetch(t *testing.T) {
 		splitChangesDTO.Splits[0].Name != "DEMO_MURMUR2" {
 		t.Error("DTO mal formed")
 	}
+
+	if splitChangesDTO.Splits[0].Configurations == nil {
+		t.Error("DTO mal formed")
+	}
+
+	if splitChangesDTO.Splits[0].Configurations["of"] != "" {
+		t.Error("DTO mal formed")
+	}
+
+	if splitChangesDTO.Splits[0].Configurations["on"] != "{\"color\": \"blue\",\"size\": 13}" {
+		t.Error("DTO mal formed")
+	}
 }
 
 func TestSpitChangesFetchHTTPError(t *testing.T) {

--- a/splitio/service/dtos/dtos_test.go
+++ b/splitio/service/dtos/dtos_test.go
@@ -47,6 +47,19 @@ func TestSplitDTO(t *testing.T) {
 			t.Error("Marshal struct mal formed [Killed]")
 		}
 
+		if splitChangesDtoFromMarshal.Splits[0].Configurations == nil {
+			t.Error("Marshal struct mal formed [Configurations]")
+		}
+
+		if splitChangesDtoFromMarshal.Splits[0].Configurations["of"] !=
+			splitChangesDtoFromMock.Splits[0].Configurations["of"] {
+			t.Error("Marshal struct mal formed [Configurations]")
+		}
+
+		if splitChangesDtoFromMarshal.Splits[0].Configurations["on"] !=
+			splitChangesDtoFromMock.Splits[0].Configurations["on"] {
+			t.Error("Marshal struct mal formed [Configurations]")
+		}
 	}
 }
 

--- a/splitio/service/dtos/split.go
+++ b/splitio/service/dtos/split.go
@@ -14,17 +14,18 @@ type SplitChangesDTO struct {
 
 // SplitDTO structure to map an Split definition fetched from JSON message.
 type SplitDTO struct {
-	ChangeNumber          int64          `json:"changeNumber"`
-	TrafficTypeName       string         `json:"trafficTypeName"`
-	Name                  string         `json:"name"`
-	TrafficAllocation     int            `json:"trafficAllocation"`
-	TrafficAllocationSeed int64          `json:"trafficAllocationSeed"`
-	Seed                  int64          `json:"seed"`
-	Status                string         `json:"status"`
-	Killed                bool           `json:"killed"`
-	DefaultTreatment      string         `json:"defaultTreatment"`
-	Algo                  int            `json:"algo"`
-	Conditions            []ConditionDTO `json:"conditions"`
+	ChangeNumber          int64             `json:"changeNumber"`
+	TrafficTypeName       string            `json:"trafficTypeName"`
+	Name                  string            `json:"name"`
+	TrafficAllocation     int               `json:"trafficAllocation"`
+	TrafficAllocationSeed int64             `json:"trafficAllocationSeed"`
+	Seed                  int64             `json:"seed"`
+	Status                string            `json:"status"`
+	Killed                bool              `json:"killed"`
+	DefaultTreatment      string            `json:"defaultTreatment"`
+	Algo                  int               `json:"algo"`
+	Conditions            []ConditionDTO    `json:"conditions"`
+	Configurations        map[string]string `json:"configurations"`
 }
 
 // MarshalBinary exports SplitDTO to JSON string

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -1,4 +1,4 @@
 package splitio
 
 // Version contains a string with the split sdk version
-const Version = "3.0.1"
+const Version = "3.1.0-rc1"

--- a/testdata/split_mock.json
+++ b/testdata/split_mock.json
@@ -9,6 +9,9 @@
   "defaultTreatment": "of",
   "changeNumber": 1491244291288,
   "algo": 2,
+  "configurations": {
+    "on": "{\"color\": \"blue\",\"size\": 13}"
+  },
   "conditions": [
     {
       "conditionType": "ROLLOUT",


### PR DESCRIPTION
# GO SDK

## Tickets covered:
* [SDKS-575: Store dynamic configs on splitChanges](https://splitio.atlassian.net/browse/SDKS-575)

## What did you accomplish?
* added logic to store dynamic configs in split changes
* updated tests

## How to test new changes?
* `go test ./...`