### PR TITLE
[SDKS-522]: Validate the split names for getTreatment and Manager methods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@
  - BlockUntilReady refactor.
  - Added getTreatmentWithConfig and getTreatmentsWithConfig methods.
  - Added support to YAML file for Localhost mode.
+ - Added validation when split does not exist in treatments and manager calls.
 3.0.1 (March 8, 2019)
  - Updated Splits refreshing rate.
 3.0.0 (Feb 19, 2019)

--- a/splitio/client/input_validator.go
+++ b/splitio/client/input_validator.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/splitio/go-client/splitio/engine/evaluator/impressionlabels"
 	"github.com/splitio/go-toolkit/datastructures/set"
 
 	"github.com/splitio/go-toolkit/logging"
@@ -233,4 +234,12 @@ func (i *inputValidation) ValidateFeatureNames(features []string, operation stri
 		}
 	}
 	return f, nil
+}
+
+func (i *inputValidation) IsSplitFound(label string, feature string, operation string) bool {
+	if label == impressionlabels.SplitNotFound {
+		i.logger.Error(fmt.Sprintf(operation+": you passed %s that does not exist in this environment, please double check what Splits exist in the web console.", feature))
+		return false
+	}
+	return true
 }

--- a/splitio/client/input_validator_test.go
+++ b/splitio/client/input_validator_test.go
@@ -394,6 +394,38 @@ func TestTreatmentValidatorWhitespacesFeatureName(t *testing.T) {
 	strMsg = ""
 }
 
+func TestTreatmentValidatorWithFeatureNonExistant(t *testing.T) {
+	result := client.Treatment("key", "feature_non_existant", nil)
+
+	if result != "control" {
+		t.Error("Should be control")
+	}
+
+	expected := "Treatment: you passed feature_non_existant that does not exist in this environment, please double check what Splits exist in the web console."
+	if strMsg != expected {
+		t.Error("Error is distinct from the expected one")
+		t.Error("Actual -> ", strMsg)
+		t.Error("Expected -> ", expected)
+	}
+	strMsg = ""
+}
+
+func TestTreatmentConfigValidatorWithFeatureNonExistant(t *testing.T) {
+	result := client.TreatmentWithConfig("key", "feature_non_existant", nil)
+
+	if result.Treatment != "control" {
+		t.Error("Should be control")
+	}
+
+	expected := "TreatmentWithConfig: you passed feature_non_existant that does not exist in this environment, please double check what Splits exist in the web console."
+	if strMsg != expected {
+		t.Error("Error is distinct from the expected one")
+		t.Error("Actual -> ", strMsg)
+		t.Error("Expected -> ", expected)
+	}
+	strMsg = ""
+}
+
 func TestTreatmentClientDestroyed(t *testing.T) {
 
 	var client2 = SplitClient{
@@ -507,6 +539,37 @@ func TestTreatmentsWhitespaceFeatures(t *testing.T) {
 	}
 
 	expected := "Treatments: split name ' some_feature  ' has extra whitespace, trimming"
+	if strMsg != expected {
+		t.Error("Error is distinct from the expected one")
+		t.Error("Actual -> ", strMsg)
+		t.Error("Expected -> ", expected)
+	}
+	strMsg = ""
+}
+
+func TestTreatmentsValidatorWithFeatureNonExistant(t *testing.T) {
+	result := client.Treatments("key", []string{"feature_non_existant"}, nil)
+
+	if result["feature_non_existant"] != "control" {
+		t.Error("Should be control")
+	}
+
+	expected := "Treatments: you passed feature_non_existant that does not exist in this environment, please double check what Splits exist in the web console."
+	if strMsg != expected {
+		t.Error("Error is distinct from the expected one")
+		t.Error("Actual -> ", strMsg)
+		t.Error("Expected -> ", expected)
+	}
+	strMsg = ""
+}
+func TestTreatmentsConfigValidatorWithFeatureNonExistant(t *testing.T) {
+	result := client.TreatmentsWithConfig("key", []string{"feature_non_existant"}, nil)
+
+	if result["feature_non_existant"].Treatment != "control" {
+		t.Error("Should be control")
+	}
+
+	expected := "TreatmentsWithConfig: you passed feature_non_existant that does not exist in this environment, please double check what Splits exist in the web console."
 	if strMsg != expected {
 		t.Error("Error is distinct from the expected one")
 		t.Error("Actual -> ", strMsg)
@@ -748,6 +811,35 @@ func TestManagerWithEmptySplit(t *testing.T) {
 	result := manager.Split("")
 
 	expected := "Split: you passed an empty split name, split name must be a non-empty string"
+	if result != nil {
+		t.Error("Wrong result")
+	}
+
+	if strMsg != expected {
+		t.Error("Error is distinct from the expected one")
+		t.Error("Actual -> ", strMsg)
+		t.Error("Expected -> ", expected)
+	}
+	strMsg = ""
+}
+
+func TestManagerWithNonExistantSplit(t *testing.T) {
+	splitStorage := mutexmap.NewMMSplitStorage()
+	manager := SplitManager{
+		splitStorage: splitStorage,
+		logger:       logger,
+		validator:    inputValidation{logger: logger},
+	}
+	factory := SplitFactory{
+		manager: &manager,
+	}
+
+	factory.status.Store(SdkReady)
+	manager.factory = &factory
+
+	result := manager.Split("non_existant")
+
+	expected := "Split: you passed non_existant that does not exist in this environment, please double check what Splits exist in the web console."
 	if result != nil {
 		t.Error("Wrong result")
 	}

--- a/splitio/client/manager.go
+++ b/splitio/client/manager.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"fmt"
+
 	"github.com/splitio/go-client/splitio/service/dtos"
 	"github.com/splitio/go-client/splitio/storage"
 	"github.com/splitio/go-toolkit/logging"
@@ -83,6 +85,7 @@ func (m *SplitManager) Split(feature string) *SplitView {
 	if split != nil {
 		return newSplitView(split)
 	}
+	m.logger.Error(fmt.Sprintf("Split: you passed %s that does not exist in this environment, please double check what Splits exist in the web console.", feature))
 	return nil
 }
 

--- a/splitio/client/manager_test.go
+++ b/splitio/client/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/splitio/go-client/splitio/service/dtos"
 	"github.com/splitio/go-client/splitio/storage/mutexmap"
 	"github.com/splitio/go-toolkit/datastructures/set"
+	"github.com/splitio/go-toolkit/logging"
 )
 
 func TestSplitManager(t *testing.T) {
@@ -43,7 +44,12 @@ func TestSplitManager(t *testing.T) {
 		},
 	}, 123)
 
-	manager := SplitManager{splitStorage: splitStorage}
+	logger := logging.NewLogger(nil)
+	manager := SplitManager{
+		splitStorage: splitStorage,
+		validator:    inputValidation{logger: logger},
+		logger:       logger,
+	}
 
 	factory := SplitFactory{
 		manager: &manager,
@@ -89,7 +95,12 @@ func TestSplitManagerWithConfigs(t *testing.T) {
 	splitStorage := mutexmap.NewMMSplitStorage()
 	splitStorage.PutMany([]dtos.SplitDTO{*valid, *killed, *noConfig}, 123)
 
-	manager := SplitManager{splitStorage: splitStorage}
+	logger := logging.NewLogger(nil)
+	manager := SplitManager{
+		splitStorage: splitStorage,
+		logger:       logger,
+		validator:    inputValidation{logger: logger},
+	}
 
 	factory := SplitFactory{
 		manager: &manager,

--- a/splitio/engine/evaluator/evaluator.go
+++ b/splitio/engine/evaluator/evaluator.go
@@ -56,7 +56,6 @@ func (e *Evaluator) Evaluate(key string, bucketingKey *string, feature string, a
 	splitDto := e.splitStorage.Get(feature)
 	var config *string
 	if splitDto == nil {
-		e.logger.Warning(fmt.Sprintf("Feature %s not found, returning control.", feature))
 		return &Result{Treatment: Control, Label: impressionlabels.SplitNotFound, Config: config}
 	}
 

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -1,4 +1,4 @@
 package splitio
 
 // Version contains a string with the split sdk version
-const Version = "4.0.0-rc1"
+const Version = "4.0.0-rc2"


### PR DESCRIPTION
# GO SDK

## Tickets covered:
* [SDKS-522: Validate the split names for getTreatment and Manager methods](https://splitio.atlassian.net/browse/SDKS-522)

## What did you accomplish?
* Added validation when split does not exist for Treatments call.
* Added validation when split does not exist for manager.
* Updated tests.

## How to test new changes?
* `go test ./...`
