### PR TITLE
Fix .Destroy issue

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+4.0.1 (May 17, 2019)
+ - Fixed bug on client.Destroy() method.
 4.0.0 (April 30, 2019)
  - Added custom Impression Listener.
  - BlockUntilReady refactor.

--- a/splitio/client/client.go
+++ b/splitio/client/client.go
@@ -113,7 +113,7 @@ func (c *SplitClient) doTreatmentCall(key interface{}, feature string, attribute
 		}
 
 		keyImpressions := []dtos.ImpressionDTO{impression}
-		toStore := []dtos.ImpressionsDTO{dtos.ImpressionsDTO{
+		toStore := []dtos.ImpressionsDTO{{
 			TestName:       feature,
 			KeyImpressions: keyImpressions,
 		}}
@@ -284,7 +284,7 @@ func (c *SplitClient) IsDestroyed() bool {
 func (c *SplitClient) Destroy() {
 	c.factory.Destroy()
 
-	if c.cfg.OperationMode == "redis-consumer" || c.cfg.OperationMode == "localhost" {
+	if c.cfg.OperationMode == "redis-consumer" {
 		return
 	}
 

--- a/splitio/client/client_test.go
+++ b/splitio/client/client_test.go
@@ -947,6 +947,8 @@ func TestBlockUntilReadyInMemory(t *testing.T) {
 	if client.Treatment("aaaaaaklmnbv", "split", nil) != "on" {
 		t.Error("Treatment error")
 	}
+
+	client.Destroy()
 }
 
 var valid = &dtos.SplitDTO{

--- a/splitio/client/client_test.go
+++ b/splitio/client/client_test.go
@@ -168,6 +168,7 @@ func TestLocalhostMode(t *testing.T) {
 		t.Error("Feature2 retrieved incorrectly")
 	}
 
+	client.Destroy()
 	file.Close()
 	os.Remove(file.Name())
 }

--- a/splitio/client/factory.go
+++ b/splitio/client/factory.go
@@ -345,7 +345,7 @@ func NewSplitFactory(apikey string, cfg *conf.SplitSdkConfig) (*SplitFactory, er
 	}
 
 	logger.Info("Sdk initialization complete!")
-
+	splitFactory.client.sync = syncTasks
 	splitFactory.client.factory = splitFactory
 	splitFactory.manager.factory = splitFactory
 

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -1,4 +1,4 @@
 package splitio
 
 // Version contains a string with the split sdk version
-const Version = "4.0.1rc1"
+const Version = "4.0.1"

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -1,4 +1,4 @@
 package splitio
 
 // Version contains a string with the split sdk version
-const Version = "4.0.0"
+const Version = "4.0.1rc1"


### PR DESCRIPTION
Fix for: https://github.com/splitio/go-client/issues/81

Restore references to sync tasks
Ensure that it's tested with localhost client instantiation