### PR TITLE
SDKS-787: Update tt validation with latest changes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-5.1.0 (Jun 13, 2019)
+5.0.1 (Jun 18, 2019)
  - Added coverage for traffic type validation existance only on ready and non localhost mode.
 5.0.0 (Jun 4, 2019)
  - Added support for optional event properties via our Track() method.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-5.0.1 (Jun 18, 2019)
+5.0.1 (Jun 19, 2019)
  - Added coverage for traffic type validation existance only on ready and non localhost mode.
 5.0.0 (Jun 4, 2019)
  - Added support for optional event properties via our Track() method.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
-4.1.0 (May 30, 2019)
+5.0.0 (Jun 4, 2019)
+ - Added support for optional event properties via our Track() method.
  - Added validation for traffic types in track call.
  - Added new label when the sdk is not ready.
  - Added multiple factory instantiation check.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+5.1.0 (Jun 13, 2019)
+ - Added coverage for traffic type validation existance only on ready and non localhost mode.
 5.0.0 (Jun 4, 2019)
  - Added support for optional event properties via our Track() method.
  - Added validation for traffic types in track call.

--- a/splitio/client/client.go
+++ b/splitio/client/client.go
@@ -372,10 +372,16 @@ func (c *SplitClient) Track(
 	}
 
 	if !c.isReady() {
-		c.logger.Warning("track: the SDK is not ready, results may be incorrect. Make sure to wait for SDK readiness before using this method")
+		c.logger.Warning("Track: the SDK is not ready, results may be incorrect. Make sure to wait for SDK readiness before using this method")
 	}
 
-	key, trafficType, eventType, value, err := c.validator.ValidateTrackInputs(key, trafficType, eventType, value)
+	key, trafficType, eventType, value, err := c.validator.ValidateTrackInputs(
+		key,
+		trafficType,
+		eventType,
+		value,
+		c.isReady() && c.apikey != "localhost",
+	)
 	if err != nil {
 		c.logger.Error(err.Error())
 		return err

--- a/splitio/client/input_validator.go
+++ b/splitio/client/input_validator.go
@@ -155,7 +155,7 @@ func checkEventType(eventType string) error {
 	return nil
 }
 
-func (i *inputValidation) checkTrafficType(trafficType string) (string, error) {
+func (i *inputValidation) checkTrafficType(trafficType string, shouldValidateExistance bool) (string, error) {
 	err := checkIsEmptyString(trafficType, "traffic type", "Track")
 	if err != nil {
 		return "", err
@@ -164,7 +164,7 @@ func (i *inputValidation) checkTrafficType(trafficType string) (string, error) {
 	if toLower != trafficType {
 		i.logger.Warning("Track: traffic type should be all lowercase - converting string to lowercase")
 	}
-	if !i.splitStorage.TrafficTypeExists(toLower) {
+	if shouldValidateExistance && !i.splitStorage.TrafficTypeExists(toLower) {
 		i.logger.Warning("Track: traffic type " + toLower + " does not have any corresponding Splits in this environment, " +
 			"make sure you’re tracking your events to a valid traffic type defined in the Split console")
 	}
@@ -188,7 +188,13 @@ func checkValue(value interface{}) error {
 }
 
 // ValidateTrackInputs implements the validation for Track call
-func (i *inputValidation) ValidateTrackInputs(key string, trafficType string, eventType string, value interface{}) (string, string, string, interface{}, error) {
+func (i *inputValidation) ValidateTrackInputs(
+	key string,
+	trafficType string,
+	eventType string,
+	value interface{},
+	shouldValidateExistance bool,
+) (string, string, string, interface{}, error) {
 	err := checkIsValidString(key, "key", "Track")
 	if err != nil {
 		return "", trafficType, eventType, value, err
@@ -199,7 +205,7 @@ func (i *inputValidation) ValidateTrackInputs(key string, trafficType string, ev
 		return key, trafficType, "", value, err
 	}
 
-	trafficType, err = i.checkTrafficType(trafficType)
+	trafficType, err = i.checkTrafficType(trafficType, shouldValidateExistance)
 	if err != nil {
 		return key, "", eventType, value, err
 	}

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -1,4 +1,4 @@
 package splitio
 
 // Version contains a string with the split sdk version
-const Version = "5.1.0-rc1"
+const Version = "5.0.1-rc1"

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -1,4 +1,4 @@
 package splitio
 
 // Version contains a string with the split sdk version
-const Version = "5.0.0-rc2"
+const Version = "5.0.0"

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -1,4 +1,4 @@
 package splitio
 
 // Version contains a string with the split sdk version
-const Version = "5.0.1-rc1"
+const Version = "5.0.1"

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -1,4 +1,4 @@
 package splitio
 
 // Version contains a string with the split sdk version
-const Version = "5.0.0"
+const Version = "5.1.0-rc1"


### PR DESCRIPTION
# GO SDK

## Tickets covered:
* [SDKS-787: Update tt validation with latest changes](https://splitio.atlassian.net/browse/SDKS-{TICKET})

## What did you accomplish?
* Added validation for tt only when is not in localhost mode and sdk is ready

## How to test new changes?
* `go test ./...`
